### PR TITLE
Add SMS CTA link for free checklist

### DIFF
--- a/app.js
+++ b/app.js
@@ -494,6 +494,15 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   initializeScrollAnimations();
+  const menuChecklistBtn = document.getElementById("menuChecklistBtn");
+  if (menuChecklistBtn) {
+    menuChecklistBtn.addEventListener("click", () => {
+      if (typeof gtag === "function") {
+        gtag("event", "sms_cta_click", { value: "menu_checklist" });
+      }
+    });
+  }
+
   initializeCarousel();
 
 }); // End DOMContentLoaded

--- a/index.html
+++ b/index.html
@@ -218,6 +218,7 @@
                         <h2 class="section-title" id="cta-walkthrough-title">Ready for a No-Pitch Walk-Through?</h2>
                         <p>I'll bring the coffee (from a local Olympia spot, of course!) and a live Toast demo tailored to your restaurant. No pressure, just a friendly chat about your needs.</p>
                         <button class="btn" id="walkThroughBtn" style="margin-top: 20px;">Book My Walk-Through with Bardya</button>
+                        <a href="sms:+13602153596?&body=MENU" id="menuChecklistBtn" class="btn" style="margin-top: 20px;">Text "MENU" for Free Checklist</a>
                     </div>
                 </div>
             </section>


### PR DESCRIPTION
## Summary
- add a free "Text MENU" SMS link to the call-to-action section
- track SMS link clicks via gtag if available

## Testing
- `git status --short`
