### PR TITLE
Add overlay illustration and faster carousel

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -12,7 +12,7 @@ document.addEventListener('DOMContentLoaded', () => {
    * ==========================================================================
    */
   const CHILIPIPER_LINK = "https://toast.chilipiper.com/personal/bardya-banihashemi";
-  const CAROUSEL_INTERVAL_TIME = 7000; // ms
+  const CAROUSEL_INTERVAL_TIME = 6300; // ms (10% faster)
   const SWIPE_THRESHOLD = 50; // px
   const SCROLL_THRESHOLD_STICKY_CTA = 100; // px
   const SCROLL_THRESHOLD_BACK_TO_TOP = 300; // px

--- a/styles/style.css
+++ b/styles/style.css
@@ -1010,6 +1010,16 @@ body {
   transform: translateY(100%);
   transition: opacity 0.4s ease-in-out, transform 0.4s ease-in-out;
 }
+.sticky-cta-bar::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: url('../hp-demo-illustration.d9507d3d.svg') center/cover no-repeat;
+  opacity: 0.3;
+  pointer-events: none;
+  z-index: 0;
+  border-radius: 8px 8px 0 0;
+}
 .sticky-cta-bar.visible {
   opacity: 1;
   transform: translateY(0);
@@ -1024,6 +1034,8 @@ body {
   animation: pulseStickyBtn 2s infinite ease-in-out;
   text-align: center;
   border-radius: var(--border-radius-button);
+  position: relative;
+  z-index: 1;
   display: inline-flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- show `hp-demo-illustration.d9507d3d.svg` over the sticky CTA bar
- bump testimonial carousel speed by 10%

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a299955b8832dba0626dc9c653c02