### PR TITLE
Enhance mobile nav UX

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -286,7 +286,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (mobileNavMenu && mobileNavMenu.classList.contains('active') && menuToggleBtn) {
       mobileNavMenu.classList.remove('active');
+      mobileNavMenu.setAttribute('aria-hidden', 'true');
       menuToggleBtn.setAttribute('aria-expanded', 'false');
+      menuToggleBtn.classList.remove('active');
+      document.body.classList.remove('no-scroll');
       const icon = menuToggleBtn.querySelector('i');
       if (icon) {
         icon.classList.remove('fa-times');
@@ -349,6 +352,9 @@ document.addEventListener('DOMContentLoaded', () => {
     menuToggleBtn.addEventListener('click', () => {
       const isExpanded = mobileNavMenu.classList.toggle('active');
       menuToggleBtn.setAttribute('aria-expanded', String(isExpanded));
+      mobileNavMenu.setAttribute('aria-hidden', String(!isExpanded));
+      menuToggleBtn.classList.toggle('active', isExpanded);
+      document.body.classList.toggle('no-scroll', isExpanded);
       const icon = menuToggleBtn.querySelector('i');
       if (icon) {
         icon.classList.toggle('fa-bars', !isExpanded);

--- a/styles/style.css
+++ b/styles/style.css
@@ -239,20 +239,20 @@ body {
 /* Mobile Navigation Menu */
 .mobile-nav-menu {
   display: none;
-  position: absolute;
-  top: 100%;
-  right: 0;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
   background-color: var(--bg-card);
-  border: 1px solid var(--border-light);
-  border-top: none;
-  border-radius: 0 0 var(--border-radius-main) var(--border-radius-main);
-  box-shadow: 0 8px 15px rgba(0, 0, 0, 0.1);
-  padding: var(--space-sm) 0;
   z-index: 1000;
-  min-width: 180px;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: var(--space-sm);
 }
 .mobile-nav-menu.active {
-  display: block;
+  display: flex;
 }
 .mobile-nav-menu a {
   display: block;
@@ -262,10 +262,15 @@ body {
   text-decoration: none;
   white-space: nowrap;
   transition: var(--transition-fast);
+  font-size: 1.2em;
 }
 .mobile-nav-menu a:hover {
   background-color: var(--bg-main);
   color: var(--accent-color);
+}
+
+body.no-scroll {
+  overflow: hidden;
 }
 
 /* ==========================================================================


### PR DESCRIPTION
## Summary
- restyle the mobile navigation overlay for full-screen display
- prevent body scrolling and set ARIA states when menu opens
- toggle `active` class on the menu button

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683f41ea1a8c832d9c08009a581db8c3