### PR TITLE
Enhance mobile nav UX

### DIFF
--- a/about.html
+++ b/about.html
@@ -53,6 +53,7 @@
         <button class="menu-toggle" id="menuToggleBtn" aria-label="Open navigation menu" aria-expanded="false" aria-controls="mobileNavMenu">
           <i class="fas fa-bars" aria-hidden="true"></i>
         </button>
+        <div class="mobile-nav-overlay" id="mobileNavOverlay" aria-hidden="true"></div>
         <div class="mobile-nav-menu" id="mobileNavMenu" aria-hidden="true">
           <a href="/about.html" class="nav-link">About Me</a>
           <a href="/resources.html" class="nav-link">Why Toast & Free Resources</a>

--- a/includes/header.html
+++ b/includes/header.html
@@ -21,6 +21,7 @@
         <button class="menu-toggle" id="menuToggleBtn" aria-label="Open navigation menu" aria-expanded="false" aria-controls="mobileNavMenu">
           <i class="fas fa-bars" aria-hidden="true"></i>
         </button>
+        <div class="mobile-nav-overlay" id="mobileNavOverlay" aria-hidden="true"></div>
         <div class="mobile-nav-menu" id="mobileNavMenu" aria-hidden="true">
           <a href="/about.html" class="nav-link">About Me</a>
           <a href="/resources.html" class="nav-link">Why Toast & Free Resources</a>

--- a/index.html
+++ b/index.html
@@ -92,6 +92,7 @@
         <button class="menu-toggle" id="menuToggleBtn" aria-label="Open navigation menu" aria-expanded="false" aria-controls="mobileNavMenu">
           <i class="fas fa-bars" aria-hidden="true"></i>
         </button>
+        <div class="mobile-nav-overlay" id="mobileNavOverlay" aria-hidden="true"></div>
         <div class="mobile-nav-menu" id="mobileNavMenu" aria-hidden="true">
           <a href="/about.html" class="nav-link">About Me</a>
           <a href="/resources.html" class="nav-link">Why Toast & Free Resources</a>

--- a/resources.html
+++ b/resources.html
@@ -53,6 +53,7 @@
         <button class="menu-toggle" id="menuToggleBtn" aria-label="Open navigation menu" aria-expanded="false" aria-controls="mobileNavMenu">
           <i class="fas fa-bars" aria-hidden="true"></i>
         </button>
+        <div class="mobile-nav-overlay" id="mobileNavOverlay" aria-hidden="true"></div>
         <div class="mobile-nav-menu" id="mobileNavMenu" aria-hidden="true">
           <a href="/about.html" class="nav-link">About Me</a>
           <a href="/resources.html" class="nav-link">Why Toast & Free Resources</a>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -57,6 +57,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // Mobile Navigation Elements
   const mobileNavMenu = document.getElementById('mobileNavMenu');
   const menuToggleBtn = document.getElementById('menuToggleBtn');
+  const mobileNavOverlay = document.getElementById('mobileNavOverlay');
 
   // Animation & Sticky Elements
   const elementsToAnimate = document.querySelectorAll('.feature-item, .glass-card, .cta-solid-bg, .local-proof, .video-section, .urgency-bar');
@@ -286,7 +287,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (mobileNavMenu && mobileNavMenu.classList.contains('active') && menuToggleBtn) {
       mobileNavMenu.classList.remove('active');
+      mobileNavMenu.setAttribute('aria-hidden', 'true');
       menuToggleBtn.setAttribute('aria-expanded', 'false');
+      menuToggleBtn.classList.remove('active');
+      document.body.classList.remove('no-scroll');
+      if (mobileNavOverlay) {
+        mobileNavOverlay.classList.remove('active');
+        mobileNavOverlay.setAttribute('aria-hidden', 'true');
+      }
       const icon = menuToggleBtn.querySelector('i');
       if (icon) {
         icon.classList.remove('fa-times');
@@ -345,16 +353,25 @@ document.addEventListener('DOMContentLoaded', () => {
    * Mobile Menu Toggle
    * ==========================================================================
    */
-  if (menuToggleBtn && mobileNavMenu) {
-    menuToggleBtn.addEventListener('click', () => {
-      const isExpanded = mobileNavMenu.classList.toggle('active');
+  if (menuToggleBtn && mobileNavMenu && mobileNavOverlay) {
+    const toggleMobileMenu = () => {
+      const isExpanded = !menuToggleBtn.classList.contains('active');
+      menuToggleBtn.classList.toggle('active', isExpanded);
+      mobileNavMenu.classList.toggle('active', isExpanded);
+      mobileNavOverlay.classList.toggle('active', isExpanded);
       menuToggleBtn.setAttribute('aria-expanded', String(isExpanded));
+      mobileNavMenu.setAttribute('aria-hidden', String(!isExpanded));
+      mobileNavOverlay.setAttribute('aria-hidden', String(!isExpanded));
+      document.body.classList.toggle('no-scroll', isExpanded);
       const icon = menuToggleBtn.querySelector('i');
       if (icon) {
         icon.classList.toggle('fa-bars', !isExpanded);
         icon.classList.toggle('fa-times', isExpanded);
       }
-    });
+    };
+
+    menuToggleBtn.addEventListener('click', toggleMobileMenu);
+    mobileNavOverlay.addEventListener('click', toggleMobileMenu);
   }
 
   /**

--- a/styles/style.css
+++ b/styles/style.css
@@ -236,23 +236,40 @@ body {
   z-index: 1005;
 }
 
+/* Dark overlay displayed when mobile menu is open */
+.mobile-nav-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+}
+.mobile-nav-overlay.active {
+  display: block;
+}
+
 /* Mobile Navigation Menu */
 .mobile-nav-menu {
-  display: none;
-  position: absolute;
-  top: 100%;
+  position: fixed;
+  top: 0;
   right: 0;
+  width: 80vw;
+  max-width: 320px;
+  height: 100vh;
   background-color: var(--bg-card);
-  border: 1px solid var(--border-light);
-  border-top: none;
-  border-radius: 0 0 var(--border-radius-main) var(--border-radius-main);
-  box-shadow: 0 8px 15px rgba(0, 0, 0, 0.1);
-  padding: var(--space-sm) 0;
-  z-index: 1000;
-  min-width: 180px;
+  z-index: 1001;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: var(--space-sm);
+  pointer-events: none;
+  transform: translateX(100%);
+  transition: transform 0.3s ease-in-out;
 }
 .mobile-nav-menu.active {
-  display: block;
+  transform: translateX(0);
+  pointer-events: auto;
 }
 .mobile-nav-menu a {
   display: block;
@@ -262,10 +279,15 @@ body {
   text-decoration: none;
   white-space: nowrap;
   transition: var(--transition-fast);
+  font-size: 1.2em;
 }
 .mobile-nav-menu a:hover {
   background-color: var(--bg-main);
   color: var(--accent-color);
+}
+
+body.no-scroll {
+  overflow: hidden;
 }
 
 /* ==========================================================================


### PR DESCRIPTION
## Summary
- restyle the mobile navigation to slide in with overlay like ToastTab
- toggle overlay visibility and prevent scroll
- update menu closing logic when navigating between pages

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683f41ea1a8c832d9c08009a581db8c3