### PR TITLE
Restore original header

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -30,7 +30,6 @@
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>
-
 <!--#include file="includes/header.html" -->
 
   <div class="content-section section-alt-bg">

--- a/styles/style.css
+++ b/styles/style.css
@@ -1,50 +1,4 @@
 /* ==========================================================================
-   0. Font Faces
-   ========================================================================== */
-@font-face {
-  font-family: 'Poppins';
-  font-style: normal;
-  font-weight: 300;
-  font-display: swap;
-  src: url('https://fonts.gstatic.com/s/poppins/v23/pxiByp8kv8JHgFVrLDz8Z1xlFQ.woff2') format('woff2');
-}
-@font-face {
-  font-family: 'Poppins';
-  font-style: normal;
-  font-weight: 400;
-  font-display: swap;
-  src: url('https://fonts.gstatic.com/s/poppins/v23/pxiEyp8kv8JHgFVrJJfecg.woff2') format('woff2');
-}
-@font-face {
-  font-family: 'Poppins';
-  font-style: normal;
-  font-weight: 500;
-  font-display: swap;
-  src: url('https://fonts.gstatic.com/s/poppins/v23/pxiByp8kv8JHgFVrLGT9Z1xlFQ.woff2') format('woff2');
-}
-@font-face {
-  font-family: 'Poppins';
-  font-style: normal;
-  font-weight: 600;
-  font-display: swap;
-  src: url('https://fonts.gstatic.com/s/poppins/v23/pxiByp8kv8JHgFVrLEj6Z1xlFQ.woff2') format('woff2');
-}
-@font-face {
-  font-family: 'Poppins';
-  font-style: normal;
-  font-weight: 700;
-  font-display: swap;
-  src: url('https://fonts.gstatic.com/s/poppins/v23/pxiByp8kv8JHgFVrLCz7Z1xlFQ.woff2') format('woff2');
-}
-@font-face {
-  font-family: 'Poppins';
-  font-style: normal;
-  font-weight: 800;
-  font-display: swap;
-  src: url('https://fonts.gstatic.com/s/poppins/v23/pxiByp8kv8JHgFVrLDD4Z1xlFQ.woff2') format('woff2');
-}
-
-/* ==========================================================================
    1. CSS Custom Properties (Variables)
    ========================================================================== */
 :root {
@@ -211,28 +165,6 @@ body {
   margin-bottom: 35px;
   text-align: center;
   font-weight: 700;
-}
-
-/* ==========================================================================
-   Announcement Banner
-   ========================================================================== */
-.announcement-banner {
-  background-color: var(--accent-color);
-  color: var(--text-on-dark-bg);
-  text-align: center;
-  padding: var(--space-sm) var(--space-lg);
-  font-size: 0.95em;
-  font-weight: 500;
-}
-.announcement-banner a {
-  color: inherit;
-  text-decoration: none;
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-xs);
-}
-.announcement-banner a:hover {
-  text-decoration: underline;
 }
 
 /* ==========================================================================
@@ -1204,7 +1136,7 @@ body.no-scroll {
    ========================================================================== */
 
 /* Larger tablets and small desktops */
-@media (min-width: 767px) {
+@media (min-width: 768px) {
   .features-grid {
     grid-template-columns: repeat(2, 1fr);
     gap: 30px;
@@ -1234,14 +1166,14 @@ body.no-scroll {
 }
 
 /* Desktops */
-@media (min-width: 1139px) {
+@media (min-width: 992px) {
   .features-grid {
     grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
   }
 }
 
 /* Smaller Tablets and Large Mobile */
-@media (max-width: 767px) {
+@media (max-width: 768px) {
   .container {
     padding: 0 var(--space-md);
   }


### PR DESCRIPTION
## Summary
- revert header markup back to using include files
- restore mobile nav overlay behavior
- clean up styles and script to match earlier layout

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683f55403770832dad3c7e77ca365c42