### PR TITLE
Restore site header/footer markup

### DIFF
--- a/about.html
+++ b/about.html
@@ -73,7 +73,58 @@
         <i class="fas fa-arrow-right" aria-hidden="true"></i>
       </a>
     </div>
-    <!--#include file="includes/header.html" -->
+<header class="site-header" role="banner">
+  <div class="container">
+    <div class="header-content">
+      <div class="header-logo">
+        <a href="/index.html" aria-label="Toast POS Home">
+          <img
+            src="toast-logo.png"
+            alt="Toast POS Logo"
+            loading="lazy"
+            class="toast-header-logo-img"
+            onerror="this.alt='Toast Logo'; this.src='https://placehold.co/120x36/FA5A0A/FFFFFF?text=Toast'; this.onerror=null;"
+          />
+        </a>
+      </div>
+      <nav class="header-actions" aria-label="Main navigation">
+        <div class="main-nav">
+          <a href="/about.html" class="nav-link">About Me</a>
+          <a href="/resources.html" class="nav-link"
+            >Why Toast & Free Resources</a
+          >
+        </div>
+        <a href="tel:+13602153596" class="btn-call-bardya">
+          <i class="fas fa-phone-alt" aria-hidden="true"></i>
+          <div>
+            <span class="call-text">Call Bardya</span>
+            <span class="phone-number">(360) 215-3596</span>
+          </div>
+        </a>
+        <button
+          class="menu-toggle"
+          id="menuToggleBtn"
+          aria-label="Open navigation menu"
+          aria-expanded="false"
+          aria-controls="mobileNavMenu"
+        >
+          <i class="fas fa-bars" aria-hidden="true"></i>
+        </button>
+        <div
+          class="mobile-nav-overlay"
+          id="mobileNavOverlay"
+          aria-hidden="true"
+        ></div>
+        <div class="mobile-nav-menu" id="mobileNavMenu" aria-hidden="true">
+          <a href="/about.html" class="nav-link">About Me</a>
+          <a href="/resources.html" class="nav-link"
+            >Why Toast & Free Resources</a
+          >
+        </div>
+      </nav>
+    </div>
+  </div>
+</header>
 
     <div class="content-section section-alt-bg">
       <div class="container">
@@ -137,7 +188,35 @@
         </main>
       </div>
     </div>
-    <!--#include file="includes/footer.html" -->
+<footer class="site-footer" role="contentinfo">
+  <div class="container">
+    <p>Bardya Banihashemi – Your Local Toast Account Executive in Olympia.</p>
+    <p>
+      Building relationships and strengthening Olympia’s restaurant community,
+      one partnership at a time.
+    </p>
+    <p>
+      Check out the official Toast website for more information:
+      <a
+        href="https://pos.toasttab.com"
+        target="_blank"
+        rel="noopener noreferrer"
+        >pos.toasttab.com</a
+      >
+    </p>
+    <p>
+      <a
+        href="https://bettercallbardya.com"
+        target="_blank"
+        rel="noopener noreferrer"
+        >bettercallbardya.com</a
+      >
+    </p>
+    <p class="copyright">
+      &copy; <span id="currentYear"></span> Toast, Inc. All rights reserved.
+    </p>
+  </div>
+</footer>
 
     <aside
       class="sticky-cta-bar"

--- a/index.html
+++ b/index.html
@@ -146,7 +146,58 @@
         <i class="fas fa-arrow-right" aria-hidden="true"></i>
       </a>
     </div>
-    <!--#include file="includes/header.html" -->
+<header class="site-header" role="banner">
+  <div class="container">
+    <div class="header-content">
+      <div class="header-logo">
+        <a href="/index.html" aria-label="Toast POS Home">
+          <img
+            src="toast-logo.png"
+            alt="Toast POS Logo"
+            loading="lazy"
+            class="toast-header-logo-img"
+            onerror="this.alt='Toast Logo'; this.src='https://placehold.co/120x36/FA5A0A/FFFFFF?text=Toast'; this.onerror=null;"
+          />
+        </a>
+      </div>
+      <nav class="header-actions" aria-label="Main navigation">
+        <div class="main-nav">
+          <a href="/about.html" class="nav-link">About Me</a>
+          <a href="/resources.html" class="nav-link"
+            >Why Toast & Free Resources</a
+          >
+        </div>
+        <a href="tel:+13602153596" class="btn-call-bardya">
+          <i class="fas fa-phone-alt" aria-hidden="true"></i>
+          <div>
+            <span class="call-text">Call Bardya</span>
+            <span class="phone-number">(360) 215-3596</span>
+          </div>
+        </a>
+        <button
+          class="menu-toggle"
+          id="menuToggleBtn"
+          aria-label="Open navigation menu"
+          aria-expanded="false"
+          aria-controls="mobileNavMenu"
+        >
+          <i class="fas fa-bars" aria-hidden="true"></i>
+        </button>
+        <div
+          class="mobile-nav-overlay"
+          id="mobileNavOverlay"
+          aria-hidden="true"
+        ></div>
+        <div class="mobile-nav-menu" id="mobileNavMenu" aria-hidden="true">
+          <a href="/about.html" class="nav-link">About Me</a>
+          <a href="/resources.html" class="nav-link"
+            >Why Toast & Free Resources</a
+          >
+        </div>
+      </nav>
+    </div>
+  </div>
+</header>
 
     <div id="page1" class="page-section active">
       <main id="page1-main-content" tabindex="-1" aria-labelledby="page1-title">
@@ -515,7 +566,35 @@
       </main>
     </div>
 
-    <!--#include file="includes/footer.html" -->
+<footer class="site-footer" role="contentinfo">
+  <div class="container">
+    <p>Bardya Banihashemi – Your Local Toast Account Executive in Olympia.</p>
+    <p>
+      Building relationships and strengthening Olympia’s restaurant community,
+      one partnership at a time.
+    </p>
+    <p>
+      Check out the official Toast website for more information:
+      <a
+        href="https://pos.toasttab.com"
+        target="_blank"
+        rel="noopener noreferrer"
+        >pos.toasttab.com</a
+      >
+    </p>
+    <p>
+      <a
+        href="https://bettercallbardya.com"
+        target="_blank"
+        rel="noopener noreferrer"
+        >bettercallbardya.com</a
+      >
+    </p>
+    <p class="copyright">
+      &copy; <span id="currentYear"></span> Toast, Inc. All rights reserved.
+    </p>
+  </div>
+</footer>
 
     <aside
       class="sticky-cta-bar"

--- a/resources.html
+++ b/resources.html
@@ -76,7 +76,58 @@
         <i class="fas fa-arrow-right" aria-hidden="true"></i>
       </a>
     </div>
-    <!--#include file="includes/header.html" -->
+<header class="site-header" role="banner">
+  <div class="container">
+    <div class="header-content">
+      <div class="header-logo">
+        <a href="/index.html" aria-label="Toast POS Home">
+          <img
+            src="toast-logo.png"
+            alt="Toast POS Logo"
+            loading="lazy"
+            class="toast-header-logo-img"
+            onerror="this.alt='Toast Logo'; this.src='https://placehold.co/120x36/FA5A0A/FFFFFF?text=Toast'; this.onerror=null;"
+          />
+        </a>
+      </div>
+      <nav class="header-actions" aria-label="Main navigation">
+        <div class="main-nav">
+          <a href="/about.html" class="nav-link">About Me</a>
+          <a href="/resources.html" class="nav-link"
+            >Why Toast & Free Resources</a
+          >
+        </div>
+        <a href="tel:+13602153596" class="btn-call-bardya">
+          <i class="fas fa-phone-alt" aria-hidden="true"></i>
+          <div>
+            <span class="call-text">Call Bardya</span>
+            <span class="phone-number">(360) 215-3596</span>
+          </div>
+        </a>
+        <button
+          class="menu-toggle"
+          id="menuToggleBtn"
+          aria-label="Open navigation menu"
+          aria-expanded="false"
+          aria-controls="mobileNavMenu"
+        >
+          <i class="fas fa-bars" aria-hidden="true"></i>
+        </button>
+        <div
+          class="mobile-nav-overlay"
+          id="mobileNavOverlay"
+          aria-hidden="true"
+        ></div>
+        <div class="mobile-nav-menu" id="mobileNavMenu" aria-hidden="true">
+          <a href="/about.html" class="nav-link">About Me</a>
+          <a href="/resources.html" class="nav-link"
+            >Why Toast & Free Resources</a
+          >
+        </div>
+      </nav>
+    </div>
+  </div>
+</header>
 
     <div class="content-section section-alt-bg">
       <div class="container">
@@ -138,7 +189,35 @@
         </main>
       </div>
     </div>
-    <!--#include file="includes/footer.html" -->
+<footer class="site-footer" role="contentinfo">
+  <div class="container">
+    <p>Bardya Banihashemi – Your Local Toast Account Executive in Olympia.</p>
+    <p>
+      Building relationships and strengthening Olympia’s restaurant community,
+      one partnership at a time.
+    </p>
+    <p>
+      Check out the official Toast website for more information:
+      <a
+        href="https://pos.toasttab.com"
+        target="_blank"
+        rel="noopener noreferrer"
+        >pos.toasttab.com</a
+      >
+    </p>
+    <p>
+      <a
+        href="https://bettercallbardya.com"
+        target="_blank"
+        rel="noopener noreferrer"
+        >bettercallbardya.com</a
+      >
+    </p>
+    <p class="copyright">
+      &copy; <span id="currentYear"></span> Toast, Inc. All rights reserved.
+    </p>
+  </div>
+</footer>
 
     <aside
       class="sticky-cta-bar"


### PR DESCRIPTION
## Summary
- bring back header and footer code in index, about, and resources pages

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_683f7c53be2c832da9b515b36a3bacf8