### PR TITLE
Enhance mobile nav display

### DIFF
--- a/includes/header.html
+++ b/includes/header.html
@@ -12,7 +12,7 @@
           />
         </a>
       </div>
-      <nav class="header-actions" aria-label="Main navigation">
+      <nav class="header-actions hide-until-scroll" aria-label="Main navigation">
         <div class="main-nav">
           <a href="/about.html" class="nav-link">About Me</a>
           <a href="/resources.html" class="nav-link"

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -18,6 +18,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const SWIPE_THRESHOLD = 50; // px
   const SCROLL_THRESHOLD_STICKY_CTA = 100; // px
   const SCROLL_THRESHOLD_BACK_TO_TOP = 300; // px
+  const SCROLL_THRESHOLD_SHOW_MENU = 50; // px
 
   /**
    * ==========================================================================
@@ -29,6 +30,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const currentYearElement = document.getElementById('currentYear');
   const siteHeader = document.querySelector('.site-header');
   const siteFooter = document.querySelector('.site-footer');
+  const headerActions = document.querySelector('.header-actions');
 
   // Popup Elements
   const schedulePopupOverlay = document.getElementById('schedule-call-popup');
@@ -279,6 +281,15 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   window.addEventListener('scroll', checkStickyCtaVisibility);
   checkStickyCtaVisibility();
+
+  function checkHeaderNavVisibility() {
+    if (headerActions) {
+      const shouldShow = window.scrollY > SCROLL_THRESHOLD_SHOW_MENU;
+      headerActions.classList.toggle('show-on-scroll', shouldShow);
+    }
+  }
+  window.addEventListener('scroll', checkHeaderNavVisibility);
+  checkHeaderNavVisibility();
 
   /**
    * ==========================================================================

--- a/styles/style.css
+++ b/styles/style.css
@@ -257,6 +257,17 @@ body {
   display: flex;
   align-items: center;
   gap: var(--space-md);
+  transition: opacity 0.3s ease;
+}
+
+.header-actions.hide-until-scroll {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.header-actions.show-on-scroll {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 /* Main Navigation */
@@ -316,7 +327,7 @@ body {
   position: fixed;
   top: 0;
   left: 0;
-  width: 100vw;
+  width: 80vw;
   height: 100vh;
   background-color: var(--bg-card);
   z-index: 1001;
@@ -341,7 +352,7 @@ body {
   text-decoration: none;
   white-space: nowrap;
   transition: var(--transition-fast);
-  font-size: 1.2em;
+  font-size: 20px;
 }
 .mobile-nav-menu a:hover {
   background-color: var(--bg-main);


### PR DESCRIPTION
## Summary
- hide site navigation until the visitor scrolls
- slide out mobile navigation 80% width with large links

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f987f84b4832d82073983798789da