### PR TITLE
Adjust sticky CTA button styling

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -1197,10 +1197,10 @@ body.no-scroll {
 .sticky-cta-bar .btn {
   background-color: var(--toast-neutral-lightest);
   color: var(--accent-color);
-  padding: 12px 30px;
-  font-size: 1.15em;
+  padding: 14px 36px; /* 15% larger dimensions */
+  font-size: 1.3em; /* slightly bigger text */
   font-weight: 600;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
   animation: pulseStickyBtn 2s infinite ease-in-out;
   text-align: center;
   border-radius: var(--border-radius-button);
@@ -1209,6 +1209,7 @@ body.no-scroll {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  will-change: transform, box-shadow;
 }
 .sticky-cta-bar .btn:hover {
   background-color: var(--bg-main);
@@ -1231,18 +1232,21 @@ body.no-scroll {
 
 @keyframes pulseStickyBtn {
   0% {
+    transform: translateY(0);
     box-shadow:
-      0 2px 8px rgba(0, 0, 0, 0.15),
-      0 0 0 0 rgba(255, 255, 255, 0.3);
+      0 4px 12px rgba(0, 0, 0, 0.2),
+      0 0 0 0 rgba(255, 255, 255, 0.4);
   }
   70% {
+    transform: translateY(-4px);
     box-shadow:
-      0 4px 12px rgba(0, 0, 0, 0.25),
-      0 0 0 10px rgba(255, 255, 255, 0);
+      0 8px 18px rgba(0, 0, 0, 0.3),
+      0 0 0 12px rgba(255, 255, 255, 0);
   }
   100% {
+    transform: translateY(0);
     box-shadow:
-      0 2px 8px rgba(0, 0, 0, 0.15),
+      0 4px 12px rgba(0, 0, 0, 0.2),
       0 0 0 0 rgba(255, 255, 255, 0);
   }
 }


### PR DESCRIPTION
## Summary
- increase sticky CTA button size
- enhance pulsing animation so it floats slightly

## Testing
- `npm run build`
- `npx prettier --write styles/style.css`
- `npx eslint "**/*.js" --quiet`

------
https://chatgpt.com/codex/tasks/task_e_683f9c4bc50c832dbf236e172fbfcb3f