### PR TITLE
Preserve banner message

### DIFF
--- a/about.html
+++ b/about.html
@@ -71,7 +71,7 @@
         <span class="announcement-badge">
           <i class="fas fa-bolt lightning-icon" aria-hidden="true"></i>
         </span>
-        Boost Olympia Restaurants: Refer &amp; Earn <strong>$1,000</strong>
+        <span class="main-text">Boost Olympia Restaurants: Refer &amp; Earn <strong>$1,000</strong></span>
         <i class="fas fa-arrow-right" aria-hidden="true"></i>
       </a>
     </div>

--- a/index.html
+++ b/index.html
@@ -164,7 +164,7 @@
         <span class="announcement-badge">
           <i class="fas fa-bolt lightning-icon" aria-hidden="true"></i>
         </span>
-        Boost Olympia Restaurants: Refer &amp; Earn <strong>$1,000</strong>
+        <span class="main-text">Boost Olympia Restaurants: Refer &amp; Earn <strong>$1,000</strong></span>
         <i class="fas fa-arrow-right" aria-hidden="true"></i>
       </a>
     </div>

--- a/resources.html
+++ b/resources.html
@@ -74,7 +74,7 @@
         <span class="announcement-badge">
           <i class="fas fa-bolt lightning-icon" aria-hidden="true"></i>
         </span>
-        Boost Olympia Restaurants: Refer &amp; Earn <strong>$1,000</strong>
+        <span class="main-text">Boost Olympia Restaurants: Refer &amp; Earn <strong>$1,000</strong></span>
         <i class="fas fa-arrow-right" aria-hidden="true"></i>
       </a>
     </div>

--- a/styles/style.css
+++ b/styles/style.css
@@ -210,6 +210,13 @@ body {
   transform: translateY(3px);
 }
 
+/* Text inside the announcement banner */
+.announcement-banner .main-text {
+  font-weight: 300;
+  margin: 0 10px;
+  font-size: 14px;
+}
+
 @keyframes pulseLightning {
   0%,
   100% {


### PR DESCRIPTION
## Summary
- revert banner announcement text while keeping new styling

## Testing
- `npm run lint` *(fails: couldn't find config)*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_683fa36af5d8832d92e228da62df4bce