### PR TITLE
Restore header buttons and adjust menu icon

### DIFF
--- a/about.html
+++ b/about.html
@@ -89,7 +89,7 @@
           />
         </a>
       </div>
-      <nav class="header-actions hide-until-scroll" aria-label="Main navigation">
+      <nav class="header-actions" aria-label="Main navigation">
         <div class="main-nav">
           <a href="/about.html" class="nav-link">About Me</a>
           <a href="/resources.html" class="nav-link"
@@ -110,7 +110,7 @@
           aria-expanded="false"
           aria-controls="mobileNavMenu"
         >
-          <i class="fas fa-bars" aria-hidden="true"></i>
+          <i class="fas fa-grip-lines" aria-hidden="true"></i>
         </button>
         <div
           class="mobile-nav-overlay"

--- a/includes/header.html
+++ b/includes/header.html
@@ -12,7 +12,7 @@
           />
         </a>
       </div>
-      <nav class="header-actions hide-until-scroll" aria-label="Main navigation">
+      <nav class="header-actions" aria-label="Main navigation">
         <div class="main-nav">
           <a href="/about.html" class="nav-link">About Me</a>
           <a href="/resources.html" class="nav-link"
@@ -33,7 +33,7 @@
           aria-expanded="false"
           aria-controls="mobileNavMenu"
         >
-          <i class="fas fa-bars" aria-hidden="true"></i>
+          <i class="fas fa-grip-lines" aria-hidden="true"></i>
         </button>
         <div
           class="mobile-nav-overlay"

--- a/index.html
+++ b/index.html
@@ -182,7 +182,7 @@
           />
         </a>
       </div>
-      <nav class="header-actions hide-until-scroll" aria-label="Main navigation">
+      <nav class="header-actions" aria-label="Main navigation">
         <div class="main-nav">
           <a href="/about.html" class="nav-link">About Me</a>
           <a href="/resources.html" class="nav-link"
@@ -203,7 +203,7 @@
           aria-expanded="false"
           aria-controls="mobileNavMenu"
         >
-          <i class="fas fa-bars" aria-hidden="true"></i>
+          <i class="fas fa-grip-lines" aria-hidden="true"></i>
         </button>
         <div
           class="mobile-nav-overlay"

--- a/resources.html
+++ b/resources.html
@@ -92,7 +92,7 @@
           />
         </a>
       </div>
-      <nav class="header-actions hide-until-scroll" aria-label="Main navigation">
+      <nav class="header-actions" aria-label="Main navigation">
         <div class="main-nav">
           <a href="/about.html" class="nav-link">About Me</a>
           <a href="/resources.html" class="nav-link"
@@ -113,7 +113,7 @@
           aria-expanded="false"
           aria-controls="mobileNavMenu"
         >
-          <i class="fas fa-bars" aria-hidden="true"></i>
+          <i class="fas fa-grip-lines" aria-hidden="true"></i>
         </button>
         <div
           class="mobile-nav-overlay"

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -343,7 +343,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const icon = menuToggleBtn.querySelector('i');
       if (icon) {
         icon.classList.remove('fa-times');
-        icon.classList.add('fa-bars');
+        icon.classList.add('fa-grip-lines');
       }
     }
 
@@ -412,7 +412,7 @@ document.addEventListener('DOMContentLoaded', () => {
       document.body.classList.toggle('no-scroll', isExpanded);
       const icon = menuToggleBtn.querySelector('i');
       if (icon) {
-        icon.classList.toggle('fa-bars', !isExpanded);
+        icon.classList.toggle('fa-grip-lines', !isExpanded);
         icon.classList.toggle('fa-times', isExpanded);
       }
     };

--- a/styles/style.css
+++ b/styles/style.css
@@ -298,13 +298,13 @@ body {
 /* Mobile Menu Toggle */
 .menu-toggle {
   display: none;
-  width: 40px;
-  height: 40px;
+  width: 32px;
+  height: 32px;
   border: none;
   border-radius: 4px;
   background-color: var(--accent-color);
   color: #fff;
-  font-size: 1.4em;
+  font-size: 1.2em;
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -1587,7 +1587,7 @@ body.no-scroll {
     gap: var(--space-xs);
   }
   .menu-toggle {
-    font-size: 1.5em;
+    font-size: 1.3em;
   }
   .announcement-banner {
     font-size: 0.8em;


### PR DESCRIPTION
## Summary
- show header actions on page load
- use a smaller 2-line menu icon
- keep the Call Bardya button

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683fb5b09904832da9ac91c0d9b4a072