### PR TITLE
Update CTAs for same-tab navigation

### DIFF
--- a/about.html
+++ b/about.html
@@ -65,8 +65,6 @@
     <div class="announcement-banner">
       <a
         href="https://pos.toasttab.com/us-referral?utm_medium=website&utm_source=sales&utm_campaign=customer-tproducts-marketing-2025-06-summer-giving-sales-25&utm_term=summer-giving-sales-25&utm_content=na"
-        target="_blank"
-        rel="noopener noreferrer"
       >
         <span class="announcement-badge">
           <i class="fas fa-bolt-lightning lightning-icon" aria-hidden="true"></i>

--- a/index.html
+++ b/index.html
@@ -158,8 +158,6 @@
     <div class="announcement-banner">
       <a
         href="https://pos.toasttab.com/us-referral?utm_medium=website&utm_source=sales&utm_campaign=customer-tproducts-marketing-2025-06-summer-giving-sales-25&utm_term=summer-giving-sales-25&utm_content=na"
-        target="_blank"
-        rel="noopener noreferrer"
       >
         <span class="announcement-badge">
           <i class="fas fa-bolt-lightning lightning-icon" aria-hidden="true"></i>

--- a/resources.html
+++ b/resources.html
@@ -68,8 +68,6 @@
     <div class="announcement-banner">
       <a
         href="https://pos.toasttab.com/us-referral?utm_medium=website&utm_source=sales&utm_campaign=customer-tproducts-marketing-2025-06-summer-giving-sales-25&utm_term=summer-giving-sales-25&utm_content=na"
-        target="_blank"
-        rel="noopener noreferrer"
       >
         <span class="announcement-badge">
           <i class="fas fa-bolt-lightning lightning-icon" aria-hidden="true"></i>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -170,7 +170,7 @@ document.addEventListener('DOMContentLoaded', () => {
   openPopupButtons.forEach((button) => {
     button.addEventListener('click', (event) => {
       event.preventDefault();
-      openSchedulePopup(button);
+      window.location.href = CHILIPIPER_LINK;
     });
   });
 


### PR DESCRIPTION
## Summary
- open ChiliPiper CTAs in the same tab
- remove `target="_blank"` from referral banner links

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fbe9e5040832db108a3f400b973ec