### PR TITLE
Add sitemap and robots for SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,9 @@ Run `npm run serve` to start an Express server that applies these headers:
 
 - `Cache-Control: no-cache, must-revalidate` for HTML
 - `Cache-Control: public, max-age=31536000, immutable` for static assets
+
+## SEO and Indexing
+
+The repository includes `robots.txt` and `sitemap.xml` at the project root.
+They are copied to the `dist/` directory during the build so search engines can
+discover all pages of the site.

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://bettercallbardya.com/sitemap.xml

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -56,6 +56,14 @@ if (fs.existsSync(cnameSrc)) {
   fs.copyFileSync(cnameSrc, path.join(distDir, 'CNAME'));
 }
 
+// copy SEO files if present
+['robots.txt', 'sitemap.xml'].forEach((file) => {
+  const src = path.join(rootDir, file);
+  if (fs.existsSync(src)) {
+    fs.copyFileSync(src, path.join(distDir, file));
+  }
+});
+
 const header = fs.readFileSync(path.join(includesDir, 'header.html'), 'utf8');
 const footer = fs.readFileSync(path.join(includesDir, 'footer.html'), 'utf8');
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://bettercallbardya.com/</loc>
+  </url>
+  <url>
+    <loc>https://bettercallbardya.com/about.html</loc>
+  </url>
+  <url>
+    <loc>https://bettercallbardya.com/resources.html</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- include sitemap.xml and robots.txt for better indexing
- update build script to copy SEO files
- document SEO files in README

## Testing
- `npm run format`
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build` *(fails: `webpack` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd831d408832d9fc7736f936a6036