### PR TITLE
Improve mobile menu animation

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -324,7 +324,7 @@ body {
 .mobile-nav-menu {
   position: fixed;
   top: 0;
-  left: 0;
+  right: 0;
   width: 80vw;
   height: 100vh;
   background-color: var(--bg-card);
@@ -335,12 +335,13 @@ body {
   align-items: center;
   gap: var(--space-sm);
   pointer-events: none;
-  transform: translateX(-100%);
+  transform: translateX(100%);
   transition: transform 0.3s ease-in-out;
 }
 .mobile-nav-menu.active {
   transform: translateX(0);
   pointer-events: auto;
+  animation: menuBounce 0.45s;
 }
 .mobile-nav-menu a {
   display: block;
@@ -359,6 +360,22 @@ body {
 
 body.no-scroll {
   overflow: hidden;
+  height: 100vh;
+}
+
+@keyframes menuBounce {
+  0% {
+    transform: translateX(100%);
+  }
+  60% {
+    transform: translateX(-15px);
+  }
+  80% {
+    transform: translateX(5px);
+  }
+  100% {
+    transform: translateX(0);
+  }
 }
 
 /* ==========================================================================


### PR DESCRIPTION
## Summary
- slide mobile menu in from the right
- add bounce animation when menu opens
- prevent page scrolling when the menu is active

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683fdb6b8564832d8194b2153f418d19