### PR TITLE
Fix missing stylesheet in build output

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -5,6 +5,9 @@
  */
 /* global gtag */
 
+// Import main stylesheet so webpack bundles it
+import '../styles/style.css';
+
 // Wait for the DOM to be fully loaded before executing scripts
 document.addEventListener('DOMContentLoaded', () => {
   /**


### PR DESCRIPTION
## Summary
- ensure `style.css` is bundled by webpack

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840780f228c832db8d5183af286d3cd