### PR TITLE
Fix mobile menu overlay

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -333,13 +333,12 @@ body {
 /* Mobile Navigation Menu */
 .mobile-nav-menu {
   position: fixed;
-  top: 0;
-  right: 0;
-  width: 340px;
-  max-width: 80vw;
+  inset: 0;
+  width: 100%;
+  max-width: none;
   height: 100vh;
   background-color: var(--bg-card);
-  border-radius: 32px 0 0 32px;
+  border-radius: 0;
   padding-top: 80px;
   padding-bottom: 80px;
   z-index: var(--z-mobile-menu);


### PR DESCRIPTION
## Summary
- change `.mobile-nav-menu` to take up the entire viewport

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407ea8f698832d9f14535ce6fda7b5