### PR TITLE
Adjust phone icon animation

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -467,17 +467,16 @@ body.no-scroll {
 .btn-call-bardya i.fa-phone-alt {
   font-size: 0.9em;
   color: #fff;
-  transform: scaleX(-1);
   animation: phoneWiggle 1.5s infinite;
 }
 
 @keyframes phoneWiggle {
   0%,
   100% {
-    transform: scaleX(-1) rotate(0deg);
+    transform: rotate(-15deg);
   }
   50% {
-    transform: scaleX(-1) rotate(180deg);
+    transform: rotate(15deg);
   }
 }
 


### PR DESCRIPTION
## Summary
- tweak the phone icon styles so it isn't flipped horizontally
- tone down the `phoneWiggle` animation

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68407e0c8984832d81649353b9e114b7