### PR TITLE
Add asset manifest generation

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -25,6 +25,30 @@ export function fingerprintImages(imagesDir: string, assetsDir: string) {
   return assetMap;
 }
 
+export function fingerprintFonts(fontsDir: string, assetsDir: string) {
+  const assetMap: Record<string, string> = {};
+  const fontRegex = /\.(woff2?|ttf|otf)$/i;
+  if (!fs.existsSync(fontsDir)) {
+    return assetMap;
+  }
+  fs.readdirSync(fontsDir).forEach((file) => {
+    if (fontRegex.test(file)) {
+      const content = fs.readFileSync(path.join(fontsDir, file));
+      const hash = crypto
+        .createHash('md5')
+        .update(content)
+        .digest('hex')
+        .slice(0, 8);
+      const ext = path.extname(file);
+      const base = path.basename(file, ext);
+      const hashedName = `${base}.${hash}${ext}`;
+      fs.writeFileSync(path.join(assetsDir, hashedName), content);
+      assetMap[`fonts/${file}`] = `assets/${hashedName}`;
+    }
+  });
+  return assetMap;
+}
+
 export function build(rootDir = path.join(__dirname, '..')) {
   const distDir = path.join(rootDir, 'dist');
   const assetsDir = path.join(distDir, 'assets');
@@ -37,12 +61,24 @@ export function build(rootDir = path.join(__dirname, '..')) {
 
   // map generated js/css files
   const assetFiles = fs.readdirSync(assetsDir);
-  const cssFile = assetFiles.find((f) => f.endsWith('.css'));
-  const jsFile = assetFiles.find((f) => f.endsWith('.js'));
+  const cssFile = assetFiles.find((f) => f.endsWith('.css')) as string;
+  const jsFile = assetFiles.find((f) => f.endsWith('.js')) as string;
 
   // fingerprint static images/icons
   const imagesDir = path.join(rootDir, 'img');
   const assetMap = fingerprintImages(imagesDir, assetsDir);
+
+  // map generated css/js into manifest
+  if (cssFile) {
+    assetMap['styles/style.css'] = `assets/${cssFile}`;
+  }
+  if (jsFile) {
+    assetMap['scripts/app.js'] = `assets/${jsFile}`;
+  }
+
+  // fingerprint fonts if present
+  const fontsDir = path.join(rootDir, 'fonts');
+  Object.assign(assetMap, fingerprintFonts(fontsDir, assetsDir));
 
   // copy and update webmanifest
   const manifestSrc = path.join(rootDir, 'site.webmanifest');
@@ -74,8 +110,6 @@ export function build(rootDir = path.join(__dirname, '..')) {
     const filePath = path.join(rootDir, page);
     const template = fs.readFileSync(filePath, 'utf8');
     let html = ejs.render(template, {}, { filename: filePath });
-    html = html.replace(/styles\/style\.css/g, `assets/${cssFile}`);
-    html = html.replace(/scripts\/app\.js/g, `assets/${jsFile}`);
     Object.entries(assetMap).forEach(([orig, hashed]) => {
       html = html.replace(new RegExp(orig, 'g'), hashed);
     });
@@ -83,6 +117,12 @@ export function build(rootDir = path.join(__dirname, '..')) {
     fs.writeFileSync(destPath, html);
     console.log(`Built ${destPath}`);
   });
+
+  // write manifest for external use
+  fs.writeFileSync(
+    path.join(distDir, 'asset-manifest.json'),
+    JSON.stringify(assetMap, null, 2),
+  );
 
   return { distDir, assetsDir };
 }

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -34,3 +34,11 @@ test('html references built assets', () => {
   assert.ok(fs.existsSync(cssFile), 'css file exists');
   assert.ok(fs.existsSync(jsFile), 'js file exists');
 });
+
+test('creates asset manifest', () => {
+  const manifestPath = path.join(rootDir, 'dist', 'asset-manifest.json');
+  assert.ok(fs.existsSync(manifestPath), 'manifest exists');
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  assert.ok(manifest['styles/style.css'], 'css entry present');
+  assert.ok(manifest['scripts/app.js'], 'js entry present');
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = {
         use: [MiniCssExtractPlugin.loader, 'css-loader'],
       },
       {
-        test: /\.(png|jpe?g|svg|ico)$/i,
+        test: /\.(png|jpe?g|svg|ico|woff2?|ttf|otf)$/i,
         type: 'asset/resource',
       },
     ],


### PR DESCRIPTION
## Summary
- fingerprint fonts alongside images
- map generated CSS/JS into asset manifest
- emit `asset-manifest.json`
- update webpack config to handle fonts
- test manifest creation in integration tests

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840b1910afc832dbacd72da790a7e82