### PR TITLE
Externalize configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+CHILIPIPER_LINK=https://toast.chilipiper.com/personal/bardya-banihashemi
+GA_MEASUREMENT_ID=GA-XXXXXXXXX

--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ npm install     # if you haven't already
 npm run build
 ```
 
+### Configuration
+
+Certain values like external URLs and analytics IDs are pulled from environment variables at build time. Create a `.env` file (see `.env.example`) with any overrides:
+
+```bash
+# .env
+CHILIPIPER_LINK=https://toast.chilipiper.com/personal/bardya-banihashemi
+GA_MEASUREMENT_ID=GA-XXXXXXXXX
+```
+
+These variables will be embedded into the bundled JavaScript and HTML so they can be changed without modifying the source code.
+
 The compiled files are written to the `dist/` directory.
 
 ### Building with Eleventy

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
 
     <script
       async
-      src="https://www.googletagmanager.com/gtag/js?id=GA_MEASUREMENT_ID"
+      src="https://www.googletagmanager.com/gtag/js?id=<%= GA_MEASUREMENT_ID %>"
     ></script>
     <script>
       window.dataLayer = window.dataLayer || [];
@@ -86,7 +86,7 @@
         dataLayer.push(arguments);
       }
       gtag('js', new Date());
-      gtag('config', 'GA_MEASUREMENT_ID');
+      gtag('config', '<%= GA_MEASUREMENT_ID %>');
     </script>
 
     <script type="application/ld+json">

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -16,6 +16,7 @@ document.addEventListener('DOMContentLoaded', () => {
    * ==========================================================================
    */
   const CHILIPIPER_LINK =
+    process.env.CHILIPIPER_LINK ||
     'https://toast.chilipiper.com/personal/bardya-banihashemi';
   const CAROUSEL_INTERVAL_TIME = 5000; // ms (20% faster)
   const SWIPE_THRESHOLD = 50; // px

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -109,7 +109,10 @@ export function build(rootDir = path.join(__dirname, '..')) {
   pages.forEach((page) => {
     const filePath = path.join(rootDir, page);
     const template = fs.readFileSync(filePath, 'utf8');
-    let html = ejs.render(template, {}, { filename: filePath });
+    const templateData = {
+      GA_MEASUREMENT_ID: process.env.GA_MEASUREMENT_ID || '',
+    };
+    let html = ejs.render(template, templateData, { filename: filePath });
     Object.entries(assetMap).forEach(([orig, hashed]) => {
       html = html.replace(new RegExp(orig, 'g'), hashed);
     });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const webpack = require('webpack');
 
 module.exports = {
   entry: './scripts/app.js',
@@ -24,6 +25,10 @@ module.exports = {
   plugins: [
     new MiniCssExtractPlugin({
       filename: 'main.[contenthash].css',
+    }),
+    new webpack.DefinePlugin({
+      'process.env.CHILIPIPER_LINK': JSON.stringify(process.env.CHILIPIPER_LINK),
+      'process.env.GA_MEASUREMENT_ID': JSON.stringify(process.env.GA_MEASUREMENT_ID),
     }),
   ],
   mode: 'production',


### PR DESCRIPTION
## Summary
- reference CHILIPIPER link from `process.env` at build time
- expose env variables to webpack via DefinePlugin
- render GA ID from env when building HTML
- document environment variables in the README
- add example `.env` file

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840b2d62364832da1e13f0e0be56fd5