### PR TITLE
Remove sticky CTA overlay artifact

### DIFF
--- a/styles/partials/_sticky-cta.css
+++ b/styles/partials/_sticky-cta.css
@@ -27,17 +27,6 @@
     opacity 0.4s ease-in-out,
     transform 0.4s ease-in-out;
 }
-.sticky-cta-bar::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: url('../../img/hp-demo-illustration.d9507d3d.svg') center/cover
-    no-repeat;
-  opacity: 0.3;
-  pointer-events: none;
-  z-index: 0;
-  border-radius: 8px 8px 0 0;
-}
 .sticky-cta-bar.visible {
   opacity: 1;
   transform: translateY(0);


### PR DESCRIPTION
## Summary
- remove the decorative background image from the sticky CTA bar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840b953c620832d900dbaa627620a97