### PR TITLE
Fix sticky CTA visuals

### DIFF
--- a/styles/partials/_hero.css
+++ b/styles/partials/_hero.css
@@ -10,6 +10,7 @@
     var(--hero-bg-image);
   background-size: cover;
   background-position: center center;
+  background-repeat: no-repeat;
   color: var(--text-on-dark-bg);
   margin-bottom: 0;
 }

--- a/styles/partials/_sticky-cta.css
+++ b/styles/partials/_sticky-cta.css
@@ -17,6 +17,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  overflow: hidden;
   z-index: 998;
   will-change: transform, opacity;
   box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
## Summary
- reinstate sticky CTA overlay and add overflow clipping
- prevent hero background image repetition

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840b953c620832d900dbaa627620a97