### PR TITLE
Remove sticky CTA overlay artifact

### DIFF
--- a/styles/partials/_hero.css
+++ b/styles/partials/_hero.css
@@ -10,6 +10,7 @@
     var(--hero-bg-image);
   background-size: cover;
   background-position: center center;
+  background-repeat: no-repeat;
   color: var(--text-on-dark-bg);
   margin-bottom: 0;
 }

--- a/styles/partials/_sticky-cta.css
+++ b/styles/partials/_sticky-cta.css
@@ -17,6 +17,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  overflow: hidden;
   z-index: 998;
   will-change: transform, opacity;
   box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.1);
@@ -27,24 +28,13 @@
     opacity 0.4s ease-in-out,
     transform 0.4s ease-in-out;
 }
-.sticky-cta-bar::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: url('../../img/hp-demo-illustration.d9507d3d.svg') center/cover
-    no-repeat;
-  opacity: 0.3;
-  pointer-events: none;
-  z-index: 0;
-  border-radius: 8px 8px 0 0;
-}
 .sticky-cta-bar.visible {
   opacity: 1;
   transform: translateY(0);
 }
 .sticky-cta-bar .btn {
-  background-color: var(--toast-neutral-lightest);
-  color: var(--accent-color);
+  background-color: var(--accent-color);
+  color: var(--text-on-dark-bg);
   padding: 14px 36px; /* 15% larger dimensions */
   font-size: 1.3em; /* slightly bigger text */
   font-weight: 600;


### PR DESCRIPTION
## Summary
- remove the decorative background image from the sticky CTA bar
- revert sticky CTA button background to accent orange and white text

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*

------
https://chatgpt.com/codex/tasks/task_e_6840b953c620832d900dbaa627620a97