### PR TITLE
Fix bottom CTA layout and add banner

### DIFF
--- a/includes/schedule-call-popup.html
+++ b/includes/schedule-call-popup.html
@@ -3,6 +3,9 @@
   id="stickyCta"
   aria-label="Sticky Call to Action"
 >
+  <div class="cta-banner">
+    Limited spots available – book your free consultation now!
+  </div>
   <button class="btn" id="stickyBookCallBtn">
     <i class="fas fa-calendar-alt" aria-hidden="true"></i> Book a call with
     Bardya

--- a/styles/partials/_sticky-cta.css
+++ b/styles/partials/_sticky-cta.css
@@ -5,7 +5,7 @@
   (Bottom of screen)
   ==========================================================================
   */
-  .sticky-cta-bar {
+.sticky-cta-bar {
   position: fixed;
   bottom: 0;
   left: 0;
@@ -15,8 +15,10 @@
   color: var(--text-on-dark-bg);
   padding: var(--space-md) var(--space-sm);
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
+  text-align: center;
   overflow: hidden;
   z-index: 998;
   will-change: transform, opacity;
@@ -54,6 +56,11 @@
   transform: translateY(-2px);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
   animation-play-state: paused;
+}
+
+.sticky-cta-bar .cta-banner {
+  font-size: 0.9em;
+  margin-bottom: var(--space-sm);
 }
 
 @keyframes pulseCtaBtn {

--- a/styles/partials/_variables.css
+++ b/styles/partials/_variables.css
@@ -22,7 +22,7 @@
   --text-on-dark-bg: var(--BCB-neutral-lightest);
   --text-accent: var(--BCB-primary-purple);
 
-  --bg-main: var(--BCB-neutral-light);
+  --bg-main: red;
   --bg-section-alt: var(--BCB-neutral-lighter);
   --bg-card: var(--BCB-neutral-lightest);
   --bg-cta-solid: var(--BCB-neutral-darkest);


### PR DESCRIPTION
## Summary
- center the sticky CTA button by using column flex layout
- add a promotional banner above the button
- change main page background to red

## Testing
- `npm install --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6840efdd7fe8832db06ed0233036e674