### PR TITLE
Center sticky CTA button

### DIFF
--- a/styles/partials/_sticky-cta.css
+++ b/styles/partials/_sticky-cta.css
@@ -8,8 +8,8 @@
 .sticky-cta-bar {
   position: fixed;
   bottom: 0;
-  left: 0;
-  width: 100%;
+  left: 50%;
+  width: auto;
   margin: 0;
   background-color: var(--accent-color);
   color: var(--text-on-dark-bg);
@@ -25,14 +25,14 @@
   box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.1);
   border-radius: 8px 8px 0 0;
   opacity: 0;
-  transform: translateY(100%);
+  transform: translate(-50%, 100%);
   transition:
     opacity 0.4s ease-in-out,
     transform 0.4s ease-in-out;
 }
 .sticky-cta-bar.visible {
   opacity: 1;
-  transform: translateY(0);
+  transform: translate(-50%, 0);
 }
 .sticky-cta-bar .btn {
   background-color: var(--accent-color);


### PR DESCRIPTION
## Summary
- center the sticky CTA bar at the bottom of the page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840f2b38b3c832d92ccf772b4373f53