### PR TITLE
Restore contact CTA on About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -127,6 +127,11 @@ permalink: about.html
               >@Bardyabani</a
             >.
           </p>
+          <div class="about-cta">
+            <button class="btn" id="aboutPageContactBtn">
+              Let’s Chat About Your Restaurant
+            </button>
+          </div>
         </main>
       </div>
     </div>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -47,6 +47,7 @@ document.addEventListener('DOMContentLoaded', () => {
   ].filter(Boolean);
   const heroProfitCheckBtn = document.getElementById('heroProfitCheckBtn');
   const walkThroughBtnEl = document.getElementById('walkThroughBtn');
+  const aboutPageContactBtn = document.getElementById('aboutPageContactBtn');
   const resourcesContactBtn = document.getElementById('resourcesContactBtn');
   const closeSchedulePopupBtn = document.getElementById(
     'closeSchedulePopupBtn',
@@ -576,6 +577,14 @@ document.addEventListener('DOMContentLoaded', () => {
     resourcesContactBtn.addEventListener('click', () => {
       if (typeof gtag === 'function') {
         gtag('event', 'resources_contact_click');
+      }
+    });
+  }
+
+  if (aboutPageContactBtn) {
+    aboutPageContactBtn.addEventListener('click', () => {
+      if (typeof gtag === 'function') {
+        gtag('event', 'about_contact_click');
       }
     });
   }

--- a/styles/partials/_about.css
+++ b/styles/partials/_about.css
@@ -154,3 +154,9 @@
 .back-to-top i {
   font-size: 1.25em;
 }
+
+/* CTA container for About and Resources pages */
+.about-cta {
+  margin: var(--space-lg) 0;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- add missing about page CTA button
- include basic styles for about-cta class
- track about page CTA clicks in analytics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840ffd31410832dbb782387b4c9e11e